### PR TITLE
Prevent wrapping of build graph

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/buildgraphview/BuildGraph/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/buildgraphview/BuildGraph/index.jelly
@@ -13,6 +13,7 @@
     #flow {
         margin: 0;
         list-style-type: none;
+        white-space: nowrap;
     }
     .column-wrapper {
         margin: 20px;


### PR DESCRIPTION
Lay out the graph horizonally to prevent wrapping and odd crossing lines.
